### PR TITLE
Error improvement and fix units tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Setup `AuthComponent`:
                     // Boolean indicating use mode "debug". (Required for unit tests)
                     // If set to `true`, default exceptions are throwns.
                     // Requires debug enabled in app.php
-                    // By default this is disable.
+                    // By default this is enable.
                     'debug' => false
                 ]
             ],

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In your app's `config/bootstrap.php` add:
 
 ```php
 // In config/bootstrap.php
-Plugin::load('ADmad/JwtAuth');
+Plugin::load('ADmad/JwtAuth', ['bootstrap' => true]);
 ```
 
 or using cake's console:
@@ -59,6 +59,12 @@ Setup `AuthComponent`:
                     // should be used to query the Users model and get user info.
                     // If set to `false` JWT's payload is directly returned.
                     'queryDatasource' => true,
+                    
+                    // Boolean indicating use mode "debug". (Required for unit tests)
+                    // If set to `true`, default exceptions are throwns.
+                    // Requires debug enabled in app.php
+                    // By default this is disable.
+                    'debug' => false
                 ]
             ],
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+\Cake\Core\Configure::write('Error.exceptionRenderer', '\ADmad\JwtAuth\Error\JwtExceptionRenderer');

--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -8,8 +8,8 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Security;
 use Exception;
-use Firebase\JWT\ExpiredException;
 use Firebase\JWT\BeforeValidException;
+use Firebase\JWT\ExpiredException;
 use Firebase\JWT\JWT;
 use Firebase\JWT\SignatureInvalidException;
 
@@ -219,7 +219,7 @@ class JwtAuthenticate extends BaseAuthenticate
             return $payload;
         } catch (Exception $e) {
             if (Configure::read('debug') && $this->_config['debug'] == true) {
-               throw $e;
+                throw $e;
             }
 
             $this->_error = $e;
@@ -250,9 +250,9 @@ class JwtAuthenticate extends BaseAuthenticate
 
         if ($this->_error instanceof ExpiredException) {
             $error = 'expired_token';
-        } else if ($this->_error instanceof BeforeValidException) {
+        } elseif ($this->_error instanceof BeforeValidException) {
             $error = 'not_yet_valid_token';
-        } else if ($this->_error instanceof SignatureInvalidException) {
+        } elseif ($this->_error instanceof SignatureInvalidException) {
             $error = 'signature_invalid';
         }
 

--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -8,8 +8,8 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Utility\Security;
 use Exception;
-use Firebase\JWT\BeforeValidException;
 use Firebase\JWT\ExpiredException;
+use Firebase\JWT\BeforeValidException;
 use Firebase\JWT\JWT;
 use Firebase\JWT\SignatureInvalidException;
 
@@ -84,7 +84,7 @@ class JwtAuthenticate extends BaseAuthenticate
      * - `key` - The key, or map of keys used to decode JWT. If not set, value
      *   of Security::salt() will be used.
      * - `default` - Mode "debug". If set to `true`, default exceptions are throwns.
-     *   By default this is disable. (Required for unit tests)
+     *   By default this is enable. (Required for unit tests)
      *
      * @param \Cake\Controller\ComponentRegistry $registry The Component registry
      *   used on this request.
@@ -101,7 +101,7 @@ class JwtAuthenticate extends BaseAuthenticate
             'fields' => ['username' => 'id'],
             'unauthenticatedException' => '\ADmad\JwtAuth\Exception\JwtException',
             'key' => null,
-            'debug' => false
+            'debug' => true
         ]);
 
         parent::__construct($registry, $config);

--- a/src/Error/JwtExceptionRenderer.php
+++ b/src/Error/JwtExceptionRenderer.php
@@ -8,7 +8,7 @@ class JwtExceptionRenderer extends ExceptionRenderer
 {
 
     /**
-     * @param \ADmad\JwtAuth\Exception\JwtException $exception
+     * @param \ADmad\JwtAuth\Exception\JwtException $exception The exception thrown.
      * @return \Cake\Network\Response The response to be sent.
      */
     public function jwt($exception)

--- a/src/Error/JwtExceptionRenderer.php
+++ b/src/Error/JwtExceptionRenderer.php
@@ -2,7 +2,6 @@
 
 namespace ADmad\JwtAuth\Error;
 
-
 use Cake\Error\ExceptionRenderer;
 
 class JwtExceptionRenderer extends ExceptionRenderer
@@ -10,7 +9,7 @@ class JwtExceptionRenderer extends ExceptionRenderer
 
     /**
      * @param \ADmad\JwtAuth\Exception\JwtException $exception
-     * @return \Cake\Network\Response
+     * @return \Cake\Network\Response The response to be sent.
      */
     public function jwt($exception)
     {
@@ -22,7 +21,7 @@ class JwtExceptionRenderer extends ExceptionRenderer
             '_serialize' => ['error', 'message', 'code', 'url']
         ]);
         $template = $this->_template($exception, $this->method, 401);
+
         return $this->_outputMessage($template);
     }
-
 }

--- a/src/Error/JwtExceptionRenderer.php
+++ b/src/Error/JwtExceptionRenderer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ADmad\JwtAuth\Error;
+
+
+use Cake\Error\ExceptionRenderer;
+
+class JwtExceptionRenderer extends ExceptionRenderer
+{
+
+    /**
+     * @param \ADmad\JwtAuth\Exception\JwtException $exception
+     * @return \Cake\Network\Response
+     */
+    public function jwt($exception)
+    {
+        $this->controller->set([
+            'error' => $exception->getError(),
+            'message' => $exception->getMessage(),
+            'url' => h($this->controller->request->here()),
+            'code' => $exception->getCode(),
+            '_serialize' => ['error', 'message', 'code', 'url']
+        ]);
+        $template = $this->_template($exception, $this->method, 401);
+        return $this->_outputMessage($template);
+    }
+
+}

--- a/src/Exception/JwtException.php
+++ b/src/Exception/JwtException.php
@@ -7,8 +7,7 @@ class JwtException extends UnauthorizedException
 {
 
     /**
-     * Identifies the error
-     * @var string
+     * @var string Identifies the error
      */
     protected $_error;
 

--- a/src/Exception/JwtException.php
+++ b/src/Exception/JwtException.php
@@ -1,0 +1,36 @@
+<?php
+namespace ADmad\JwtAuth\Exception;
+
+use Cake\Network\Exception\UnauthorizedException;
+
+class JwtException extends UnauthorizedException
+{
+
+    /**
+     * Identifies the error
+     * @var string
+     */
+    protected $_error;
+
+    /**
+     * JwtException constructor.
+     * @param null $message
+     * @param string $error
+     * @param int $code
+     */
+    public function __construct($message = null, $error = 'invalid_token', $code = 401)
+    {
+        parent::__construct($message, $code);
+        $this->_error = $error;
+    }
+
+    /**
+     * Get error value
+     * @return string
+     */
+    public function getError()
+    {
+        return $this->_error;
+    }
+
+}

--- a/src/Exception/JwtException.php
+++ b/src/Exception/JwtException.php
@@ -14,9 +14,9 @@ class JwtException extends UnauthorizedException
 
     /**
      * JwtException constructor.
-     * @param null $message
-     * @param string $error
-     * @param int $code
+     * @param null $message Exception message
+     * @param string $error Error indication
+     * @param int $code HTTP code
      */
     public function __construct($message = null, $error = 'invalid_token', $code = 401)
     {
@@ -32,5 +32,4 @@ class JwtException extends UnauthorizedException
     {
         return $this->_error;
     }
-
 }

--- a/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -32,14 +32,19 @@ class JwtAuthenticateTest extends TestCase
 
         Security::salt('secret-key');
 
-        $this->Registry = $this->createMock('Cake\Controller\ComponentRegistry');
+        if (method_exists($this, 'createMock')) {
+            $this->Registry = $this->createMock('Cake\Controller\ComponentRegistry');
+            $this->response = $this->createMock('Cake\Network\Response');
+        } else {
+            $this->Registry = $this->getMock('Cake\Controller\ComponentRegistry');
+            $this->response = $this->getMock('Cake\Network\Response');
+        }
+
         $this->auth = new JwtAuthenticate($this->Registry, [
             'userModel' => 'Users',
         ]);
 
         $this->token = JWT::encode(['sub' => 1], Security::salt());
-
-        $this->response = $this->createMock('Cake\Network\Response');
     }
 
     /**

--- a/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -98,7 +98,12 @@ class JwtAuthenticateTest extends TestCase
         $result = $this->auth->getUser($request, $this->response);
         $this->assertEquals($expected, $result);
 
-        $this->expectException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
+
         $request->env('HTTP_AUTHORIZATION', 'Bearer foobar');
         $result = $this->auth->getUser($request, $this->response);
         $this->assertFalse($result);
@@ -172,7 +177,12 @@ class JwtAuthenticateTest extends TestCase
         $result = $this->auth->getUser($request, $this->response);
         $this->assertEquals($expected, $result);
 
-        $this->expectException('UnexpectedValueException');
+        if (method_exists($this, 'expectException')) {
+            $this->expectException('UnexpectedValueException');
+        } else {
+            $this->setExpectedException('UnexpectedValueException');
+        }
+
         $request->env('HTTP_AUTHORIZATION', 'Bearer foobar');
         $result = $this->auth->getUser($request, $this->response);
         $this->assertFalse($result);

--- a/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace ADmad\JwtAuth\Auth\Test\TestCase\Auth;
+namespace ADmad\JwtAuth\Test\TestCase\Auth;
 
 use ADmad\JwtAuth\Auth\JwtAuthenticate;
 use Cake\Core\Configure;
@@ -32,14 +32,14 @@ class JwtAuthenticateTest extends TestCase
 
         Security::salt('secret-key');
 
-        $this->Registry = $this->getMock('Cake\Controller\ComponentRegistry');
+        $this->Registry = $this->createMock('Cake\Controller\ComponentRegistry');
         $this->auth = new JwtAuthenticate($this->Registry, [
             'userModel' => 'Users',
         ]);
 
         $this->token = JWT::encode(['sub' => 1], Security::salt());
 
-        $this->response = $this->getMock('Cake\Network\Response');
+        $this->response = $this->createMock('Cake\Network\Response');
     }
 
     /**
@@ -93,7 +93,7 @@ class JwtAuthenticateTest extends TestCase
         $result = $this->auth->getUser($request, $this->response);
         $this->assertEquals($expected, $result);
 
-        $this->setExpectedException('UnexpectedValueException');
+        $this->expectException('UnexpectedValueException');
         $request->env('HTTP_AUTHORIZATION', 'Bearer foobar');
         $result = $this->auth->getUser($request, $this->response);
         $this->assertFalse($result);
@@ -167,7 +167,7 @@ class JwtAuthenticateTest extends TestCase
         $result = $this->auth->getUser($request, $this->response);
         $this->assertEquals($expected, $result);
 
-        $this->setExpectedException('UnexpectedValueException');
+        $this->expectException('UnexpectedValueException');
         $request->env('HTTP_AUTHORIZATION', 'Bearer foobar');
         $result = $this->auth->getUser($request, $this->response);
         $this->assertFalse($result);
@@ -198,7 +198,7 @@ class JwtAuthenticateTest extends TestCase
     }
 
     /**
-     * @expectedException Cake\Network\Exception\UnauthorizedException
+     * @expectedException \ADmad\JwtAuth\Exception\JwtException
      * @expectedExceptionMessage Auth error
      */
     public function testUnauthenticated()


### PR DESCRIPTION
I improved the error returns and I fixed the use of deprecated functions in unit tests.

[FIXED] Travis-CI tests has failed because when PHP > 7.0, the function getMock is deprecated. But when PHP < 7.0, the function createMock not exist.
