### PR TITLE
Fix #43

### DIFF
--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -186,7 +186,7 @@ class JwtAuthenticate extends BaseAuthenticate
         }
 
         $header = $request->header($config['header']);
-        if ($header) {
+        if ($header && stripos($header, $config['prefix']) === 0) {
             return $this->_token = str_ireplace($config['prefix'] . ' ', '', $header);
         }
 


### PR DESCRIPTION
Check if the Authorization header prefix fits the expected value, don't try to decode wrong data.
No exceptions thrown on wrong prefix so that other Auth methods can continue (Basic).

Testcases need to be updated :p