### PR TITLE
Fix #52

### DIFF
--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -91,13 +91,16 @@ class JwtAuthenticate extends BaseAuthenticate
             'header' => 'authorization',
             'prefix' => 'bearer',
             'parameter' => 'token',
-            'allowedAlgs' => ['HS256'],
             'queryDatasource' => true,
             'fields' => ['username' => 'id'],
             'unauthenticatedException' => '\Cake\Network\Exception\UnauthorizedException',
             'key' => null,
         ]);
-
+        if(!array_key_exists('allowedAlgs',$config) || empty($config['allowedAlgs']) {
+            $this->config([
+                'allowedAlgs' => ['HS256'],
+            ]);
+        }
         parent::__construct($registry, $config);
     }
 

--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -97,7 +97,7 @@ class JwtAuthenticate extends BaseAuthenticate
             'key' => null,
         ]);
 
-        if (!array_key_exists('allowedAlgs', $config) || empty($config['allowedAlgs']) {
+        if (!array_key_exists('allowedAlgs', $config) || empty($config['allowedAlgs'])) {
             $this->config([
                 'allowedAlgs' => ['HS256'],
             ]);

--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -96,11 +96,13 @@ class JwtAuthenticate extends BaseAuthenticate
             'unauthenticatedException' => '\Cake\Network\Exception\UnauthorizedException',
             'key' => null,
         ]);
-        if(!array_key_exists('allowedAlgs',$config) || empty($config['allowedAlgs']) {
+
+        if (!array_key_exists('allowedAlgs', $config) || empty($config['allowedAlgs']) {
             $this->config([
                 'allowedAlgs' => ['HS256'],
             ]);
         }
+
         parent::__construct($registry, $config);
     }
 

--- a/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -276,4 +276,24 @@ class JwtAuthenticateTest extends TestCase
         $result = $auth->getUser($request, $this->response);
         $this->assertEquals($payload, $result);
     }
+
+    /**
+     * test if allowedAlgs gets overwritten, not merged with default config.
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testOverwriteAlgs()
+    {
+        $key = 'my-custom-key';
+        $auth = new JwtAuthenticate($this->Registry, [
+            'allowedAlgs' => 'RS256',
+        ]);
+
+        $payload = ['sub' => 100];
+        $token = Jwt::encode($payload, $key);
+        $request = new Request();
+        $request->env('HTTP_AUTHORIZATION', 'Bearer ' . $token);
+
+        $result = $auth->getUser($request, $this->response);
+    }
 }

--- a/tests/TestCase/Auth/JwtAuthenticateTest.php
+++ b/tests/TestCase/Auth/JwtAuthenticateTest.php
@@ -280,13 +280,13 @@ class JwtAuthenticateTest extends TestCase
     /**
      * test if allowedAlgs gets overwritten, not merged with default config.
      *
-     * @expectedException InvalidArgumentException
+     * @expectedException UnexpectedValueException
      */
     public function testOverwriteAlgs()
     {
         $key = 'my-custom-key';
         $auth = new JwtAuthenticate($this->Registry, [
-            'allowedAlgs' => 'RS256',
+            'allowedAlgs' => ['RS256'],
         ]);
 
         $payload = ['sub' => 100];


### PR DESCRIPTION
Only add the default Alg HS256 if none are provided in the custom config, the array gets merged deep, so any default value set will be available whatever gets set from the config (in addition to it).
This is a serve security thread: When setting RS256 it's possible to make up a new token with the public key only that would verify with the HS256 algo!