### PR TITLE
Fix typo

### DIFF
--- a/src/Auth/JwtAuthenticate.php
+++ b/src/Auth/JwtAuthenticate.php
@@ -79,7 +79,7 @@ class JwtAuthenticate extends BaseAuthenticate
      * - `finder` - Finder method.
      * - `unauthenticatedException` - Fully namespaced exception name. Exception to
      *   throw if authentication fails. Set to false to do nothing.
-     *   Defaults to '\Cake\Htttp\Exception\UnauthorizedException'.
+     *   Defaults to '\Cake\Http\Exception\UnauthorizedException'.
      * - `key` - The key, or map of keys used to decode JWT. If not set, value
      *   of Security::salt() will be used.
      *


### PR DESCRIPTION
`\Cake\Http\Exception\UnauthorizedException` not `\Cake\Htttp\Exception\UnauthorizedException`